### PR TITLE
Refactor Client.EditPost

### DIFF
--- a/post.go
+++ b/post.go
@@ -20,8 +20,8 @@ type (
 		Content string `json:"content"`
 	}
 
-	// PostUpdateParams has parameters for editing a sub.club post.
-	PostUpdateParams struct {
+	// postUpdateParams is an internal struct for editing a sub.club post.
+	postUpdateParams struct {
 		PostID  string `json:"postId"`
 		Content string `json:"content"`
 	}
@@ -54,10 +54,14 @@ func (c *Client) Post(pp *PostParams) (*Post, error) {
 	return p, nil
 }
 
-// EditPost edits the given post with the supplied PostUpdateParams.
-func (c *Client) EditPost(pup *PostUpdateParams) (*Post, error) {
+// UpdatePost edits the given post with the supplied PostParams.
+func (c *Client) UpdatePost(postID string, pp *PostParams) (*Post, error) {
 	p := &Post{}
 
+	pup := &postUpdateParams{
+		PostID:  postID,
+		Content: pp.Content,
+	}
 	env, err := c.post("/post/edit", pup, p)
 	if err != nil {
 		return nil, err

--- a/post_test.go
+++ b/post_test.go
@@ -18,7 +18,7 @@ func TestPost(t *testing.T) {
 	t.Logf("Post: %+v", p)
 }
 
-func TestEditPost(t *testing.T) {
+func TestUpdatePost(t *testing.T) {
 	c := NewClient(os.Getenv("API_KEY"))
 
 	p, err := c.Post(&PostParams{
@@ -31,8 +31,7 @@ func TestEditPost(t *testing.T) {
 		t.Fatalf("FAILED to post")
 	}
 
-	ep, err := c.EditPost(&PostUpdateParams{
-		PostID:  p.PostID,
+	ep, err := c.UpdatePost(p.PostID, &PostParams{
 		Content: "UPDATED post!",
 	})
 	if err != nil {


### PR DESCRIPTION
- Renames method to UpdatePost
- Accepts a postID as a parameter, instead of part of a struct
- Un-exports PostUpdateParams